### PR TITLE
Lock pipelines to Python 3.10

### DIFF
--- a/.github/workflows/python_setup.yml
+++ b/.github/workflows/python_setup.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.x' # Version range or exact version of a Python version to use, using SemVer's version range syntax
+          python-version: '3.10' # Version range or exact version of a Python version to use, using SemVer's version range syntax
       
       - name: Install Python dependencies
         run: |

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Set up python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.x' # Version range or exact version of a Python version to use, using SemVer's version range syntax
+          python-version: '3.10' # Version range or exact version of a Python version to use, using SemVer's version range syntax
       
       - name: Install Python dependencies
         run: |


### PR DESCRIPTION
After Github Actions started to use Python 3.11 when specifying 3.x run time of both pipelines increased drastically. 
Checking if locking Python 3.10 helps